### PR TITLE
Added royalties

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6545,6 +6545,7 @@
       "integrity": "sha512-EL39OpP8FcZ99ne1Rno3jImfb92Nectd4iVsZzoEUCBfbwHe7sr0k+i45guoruSoP8nMUE81Mov2s8I5pi6d9Q==",
       "requires": {
         "bn.js": "^4.11.8",
+        "ethers": "^4.0.32",
         "lodash": "^4.17.13",
         "web3": "1.2.1"
       },
@@ -6572,6 +6573,57 @@
             "xhr-request-promise": "^0.1.2"
           }
         },
+        "ethers": {
+          "version": "4.0.49",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.49.tgz",
+          "integrity": "sha512-kPltTvWiyu+OktYy1IStSO16i2e7cS9D9OxZ81q2UUaiNPVrm/RTcbxamCXF9VUSKzJIdJV68EAIhTEVBalRWg==",
+          "requires": {
+            "aes-js": "3.0.0",
+            "bn.js": "^4.11.9",
+            "elliptic": "6.5.4",
+            "hash.js": "1.1.3",
+            "js-sha3": "0.5.7",
+            "scrypt-js": "2.0.4",
+            "setimmediate": "1.0.4",
+            "uuid": "2.0.1",
+            "xmlhttprequest": "1.8.0"
+          },
+          "dependencies": {
+            "elliptic": {
+              "version": "6.5.4",
+              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+              "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+              "requires": {
+                "bn.js": "^4.11.9",
+                "brorand": "^1.1.0",
+                "hash.js": "^1.0.0",
+                "hmac-drbg": "^1.0.1",
+                "inherits": "^2.0.4",
+                "minimalistic-assert": "^1.0.1",
+                "minimalistic-crypto-utils": "^1.0.1"
+              }
+            },
+            "hash.js": {
+              "version": "1.1.3",
+              "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+              "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+              "requires": {
+                "inherits": "^2.0.3",
+                "minimalistic-assert": "^1.0.0"
+              }
+            },
+            "scrypt-js": {
+              "version": "2.0.4",
+              "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
+              "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw=="
+            },
+            "setimmediate": {
+              "version": "1.0.4",
+              "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
+              "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48="
+            }
+          }
+        },
         "fs-extra": {
           "version": "4.0.3",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
@@ -6581,6 +6633,11 @@
             "jsonfile": "^4.0.0",
             "universalify": "^0.1.0"
           }
+        },
+        "js-sha3": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
+          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
         },
         "jsonfile": {
           "version": "4.0.0",

--- a/zos.json
+++ b/zos.json
@@ -3,7 +3,8 @@
   "name": "poap",
   "version": "0.1.0",
   "contracts": {
-    "Poap": "Poap"
+    "Poap": "Poap",
+    "XPoap": "XPoap"
   },
   "dependencies": {},
   "compiler": {


### PR DESCRIPTION
This PR implements the royalty feature for POAP, it includes:

- Owner function to allow the owner to manage the collection on OpenSea and set royalties

![OpenSea royalties](https://user-images.githubusercontent.com/12197082/157866256-0596092c-f753-4101-9fdf-b9f4a2fc6031.png)

- EIP2981 to allow marketplaces like Eporio to automatically pick up royalties

After the contract has been updated the "setRoyaltyInfo" function should be called to set the parameters for the royalties.
example:

```
setRoyaltyInfo(
  '0x0000000000000000000000000000000000000000', // royalty recipient
  100000000000000000, // 0.1 xDAI
  1000 // bps equivalent of 10%
)
```


Notes:
- In this PR I have updated and tested manually the XPoap contract as specified by the Readme. In the latest version of OpenZeppelin it is suggested to create a second version of the file instead (XPoapV2). I am not familiar with the deprecated version of Openzeppelin upgradeable contracts, please let me know if the files should be arranged in a different way.
- The updates have been added to the XPoap contract instead of using Polymorphism to ensure the storage layout will be preserved.



